### PR TITLE
詳細情報表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index,:show]
 
   def index
     @items = Item.all.order(created_at: "DESC")
@@ -18,8 +18,10 @@ class ItemsController < ApplicationController
     end
   end
     
-    def show
-    end
+  def show
+    @items = Item.find(params[:id])
+  end
+
 
   private
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
     <% if @items.present? %>
       <% @items.each do |item| %>     
       <li class='list'>
-        <%= link_to '#' do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" if item.image.attached?%>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -3,67 +3,75 @@
 <%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
-    <h2 class="name">
-      <%= "商品名" %>
-    </h2>
-    <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
+      <h2 class="name">
+      <%= @items.name %> 
+      </h2>    
+      <div class='item-img-content'>
+        <%= image_tag @items.image, class: "item-box-img" if @items.image.attached?%>
+          
+          <% if @items.present? %>
+          <div class='sold-out'>
+          <% else %>
+            <span>Sold Out!!</span>
+          </div>
+          <% end %>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
-    </div>
-    <div class="item-price-box">
-      <span class="item-price">
-        ¥ 999,999,999
-      </span>
-      <span class="item-postage">
-        <%= "配送料負担" %>
-      </span>
-    </div>
+
+      <div class='item-price-box'>
+              <span class="item-price">
+              ¥<%= @items.price %>
+              </span>
+               <span class="item-postage">
+               <%= @items.shipping_charge.name %>
+              </span>
+      </div>
+  </div>
+    
+  
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+   <% if user_signed_in? %>
+   <% if current_user.id == @items.user_id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <% else %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% end %>
+  <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @items.product_description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @items.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @items.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @items.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @items.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @items.shipping_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @items.estimated_shipping_date.name %></td>
         </tr>
       </tbody>
     </table>
@@ -103,7 +111,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @items.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   
   devise_for :users
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
   root to: 'items#index' 
   
   


### PR DESCRIPTION
# What
詳細情報表示機能の実装

# Why
フリマアプリでは、出品した商品の詳細を確認できる必要があるため。


ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/e66d8e9603d1c9a60b0e90934718d457

ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/923d7dd153f8d8fe6f3574c655dc3010

ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/05dd7db3320fa67c5cd4582de92e96dc
